### PR TITLE
Disable frontend ingress in values files

### DIFF
--- a/lab10_helm_dependencies_begin/chart/guestbook/values.yaml
+++ b/lab10_helm_dependencies_begin/chart/guestbook/values.yaml
@@ -7,7 +7,7 @@ backend:
     enabled: false
 frontend:
   ingress:
-    enabled: true
+    enabled: false
 
 ingress:
   hosts:

--- a/lab10_helm_dependencies_child-parent/chart/guestbook/values.yaml
+++ b/lab10_helm_dependencies_child-parent/chart/guestbook/values.yaml
@@ -8,7 +8,7 @@ backend:
     enabled: false
 frontend:
   ingress:
-    enabled: true
+    enabled: false
 database:
   enabled: true
 tags:

--- a/lab10_helm_dependencies_exports/chart/guestbook/values.yaml
+++ b/lab10_helm_dependencies_exports/chart/guestbook/values.yaml
@@ -8,7 +8,7 @@ backend:
     enabled: false
 frontend:
   ingress:
-    enabled: true
+    enabled: false
 database:
   enabled: true
 tags:

--- a/lab9_helm_template_final/chart/guestbook/values.yaml
+++ b/lab9_helm_template_final/chart/guestbook/values.yaml
@@ -7,7 +7,7 @@ backend:
     enabled: false
 frontend:
   ingress:
-    enabled: true
+    enabled: false
 
 ingress:
   hosts:


### PR DESCRIPTION
You can't create both a `DEV` and `TEST` deployment without getting an `"/" is already defined in ingress` error, because the ingress from the frontend chart gets used.